### PR TITLE
Refactor/update atomworks paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "torch>=2.2.0,<3",
     "lightning>=2.4.0,<2.5",
     "einops>=0.8.0,<1",
-    "einx>=0.1.0,<1",
     "opt_einsum>=3.4.0,<4",
     "dm-tree>=0.1.6,<1",
     # ... kernels (Linux only)
@@ -43,13 +42,18 @@ dependencies = [
     # ... typing & documentation
     "jaxtyping>=0.2.17,<1",
     "beartype>=0.18.0,<1",
-
     # ... dataloading
     "atomworks==1.0.0",
 ]
 
-
 [project.optional-dependencies]
+cuda = [
+    # ... kernels
+    "cuequivariance_ops_cu12>=0.5.0",
+    "cuequivariance_ops_torch_cu12>=0.5.0",
+    "cuequivariance_torch>=0.5.0",
+]
+
 dev = [
     # Linters & formatters
     "ruff==0.8.3",

--- a/src/modelhub/callbacks/dump_validation_structures.py
+++ b/src/modelhub/callbacks/dump_validation_structures.py
@@ -1,7 +1,7 @@
 from os import PathLike
 from pathlib import Path
 
-from atomworks.ml.common import parse_example_id
+from atomworks.ml.example_id import parse_example_id
 from beartype.typing import Any
 
 from modelhub.callbacks.base import BaseCallback

--- a/src/modelhub/callbacks/train_logging.py
+++ b/src/modelhub/callbacks/train_logging.py
@@ -2,7 +2,7 @@ import time
 from collections import defaultdict
 
 import pandas as pd
-from atomworks.ml.common import parse_example_id
+from atomworks.ml.example_id import parse_example_id
 from beartype.typing import Any
 from lightning.fabric.wrappers import (
     _FabricOptimizer,

--- a/src/modelhub/cli.py
+++ b/src/modelhub/cli.py
@@ -3,9 +3,9 @@ import os
 import typer
 from hydra import compose, initialize_config_dir
 
-from modelhub.inference import run_inference
+app = typer.Typer(pretty_exceptions_show_locals=False, pretty_exceptions_short=True)
 
-app = typer.Typer()
+DOCS_URL = "https://github.com/RosettaCommons/modelforge/blob/production/src/modelhub/inference_engines/README.md"
 
 
 @app.command(
@@ -13,22 +13,39 @@ app = typer.Typer()
 )
 def fold(ctx: typer.Context):
     """Run structure prediction using hydra config overrides or simple input file."""
-    config_path = os.path.join(
-        os.environ.get("PROJECT_PATH", os.environ["PROJECT_ROOT"]), "configs"
-    )
-
     # Get all arguments
     args = ctx.params.get("args", []) + ctx.args
 
     # Parse arguments
     hydra_overrides = []
 
-    if len(args) == 1 and "=" not in args[0]:
-        # Old style: single positional argument assumed to be inputs
-        hydra_overrides.append(f"inputs={args[0]}")
+    # Basic error handling & user conviencence
+    if any(problematic_args := [arg for arg in args if arg.startswith("--")]):
+        raise ValueError(
+            "NOTE: The RF3 CLI does not support the --arg=value syntax "
+            "because we use Hydra's override grammar. This means we use "
+            "arg=value instead without the '--'. For more info please "
+            f"refer to {DOCS_URL}. "
+            f"Problematic arguments: {problematic_args}"
+        )
+
+    if any(arg.startswith("inputs=") for arg in args):
+        if "=" not in args[0]:
+            raise ValueError(
+                "Cannot simultaneously specify inputs via positional argument and the `inputs=...` syntax. "
+                "Please either use `rf3 fold path/to/inputs.json` or `rf3 fold inputs=path/to/inputs.json`. "
+                "You may use .cif / .pdb / .json files as inputs. For more information please refer to: "
+                f"{DOCS_URL}"
+            )
+    elif "=" not in args[0]:
+        args[0] = f"inputs={args[0]}"
     else:
-        # New style: all arguments are hydra overrides
-        hydra_overrides.extend(args)
+        raise ValueError(
+            "Missing the `inputs=...` argument. Please use either `rf3 fold path/to/inputs.json` or "
+            "`rf3 fold inputs=path/to/inputs.cif`."
+        )
+
+    hydra_overrides.extend(args)
 
     # Ensure we have at least a default inference_engine if not specified
     has_inference_engine = any(
@@ -36,6 +53,13 @@ def fold(ctx: typer.Context):
     )
     if not has_inference_engine:
         hydra_overrides.append("inference_engine=rf3")
+
+    # ... lazy import to speed up CLI
+    from modelhub.inference import run_inference
+
+    config_path = os.path.join(
+        os.environ.get("PROJECT_PATH", os.environ["PROJECT_ROOT"]), "configs"
+    )
 
     with initialize_config_dir(config_dir=config_path, version_base="1.3"):
         cfg = compose(config_name="inference", overrides=hydra_overrides)

--- a/src/modelhub/data/paired_msa.py
+++ b/src/modelhub/data/paired_msa.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from atomworks.common import exists
 from atomworks.enums import ChainType
-from atomworks.ml.common import exists
 from atomworks.ml.datasets import logger
 from atomworks.ml.datasets.datasets import StructuralDatasetWrapper
 from atomworks.ml.datasets.parsers import (

--- a/src/modelhub/data/pipelines.py
+++ b/src/modelhub/data/pipelines.py
@@ -2,14 +2,14 @@ from os import PathLike
 from pathlib import Path
 
 import numpy as np
-from atomworks.enums import ChainType
-from atomworks.io.constants import (
+from atomworks.common import exists
+from atomworks.constants import (
     AF3_EXCLUDED_LIGANDS,
     STANDARD_AA,
     STANDARD_DNA,
     STANDARD_RNA,
 )
-from atomworks.ml.common import exists
+from atomworks.enums import ChainType
 from atomworks.ml.encoding_definitions import RF2AA_ATOM36_ENCODING, AF3SequenceEncoding
 from atomworks.ml.transforms.af3_reference_molecule import (
     GetAF3ReferenceMoleculeFeatures,

--- a/src/modelhub/inference_engines/rf3.py
+++ b/src/modelhub/inference_engines/rf3.py
@@ -6,10 +6,10 @@ import hydra
 import numpy as np
 import pandas as pd
 import torch
+from atomworks.common import as_list
 from atomworks.enums import GroundTruthConformerPolicy
 from atomworks.io import parse
 from atomworks.io.utils.selection import AtomSelection
-from atomworks.ml.common import as_list
 from biotite.structure import AtomArray
 from lightning.fabric import seed_everything
 from omegaconf import OmegaConf

--- a/tests/test_ground_truth_template.py
+++ b/tests/test_ground_truth_template.py
@@ -3,7 +3,7 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
-from cifutils.constants import (
+from atomworks.constants import (
     STANDARD_AA,
     STANDARD_DNA,
     STANDARD_RNA,

--- a/tests/test_inference_pipelines.py
+++ b/tests/test_inference_pipelines.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import hydra
 import numpy as np
 import pytest
-from atomworks.io import parse
+from atomworks.io.parser import parse
 from hydra import compose, initialize
 
 from modelhub.utils.inference import build_file_paths_for_prediction

--- a/tests/test_inference_regression.py
+++ b/tests/test_inference_regression.py
@@ -69,7 +69,7 @@ def test_inference_regression():
         cfg = compose(
             config_name="inference",
             overrides=[
-                "inference_engine=af3",
+                "inference_engine=rf3",
                 f"inputs={inputs}",
                 "annotate_b_factor_with_plddt=true",
                 "one_model_per_file=false",


### PR DESCRIPTION
This PR updates `rf3` to be in sync with the latest updates to [atomworks](https://github.com/RosettaCommons/atomworks), which included a fille consolidation of constants and common utilities.

It also adds some basic error messages to the CLI to avoid users being caught off-guard by the hydra syntax instead of the usual CLI syntax many are used to.

NOTE: Before merging this we should release an increment the atomworks `pypi` version, to ensure this update allows modelforge to work with the pip-installable version.