### PR TITLE
Update interface parquet file name for training rfd3

### DIFF
--- a/models/rfd3/configs/datasets/train/pdb/af3_train_interface.yaml
+++ b/models/rfd3/configs/datasets/train/pdb/af3_train_interface.yaml
@@ -7,7 +7,7 @@ dataset:
     base_dir: ${paths.data.pdb_data_dir}
   dataset:
     name: interface
-    data: ${paths.data.pdb_parquet_dir}/interfaces_df_train.parquet
+    data: ${paths.data.pdb_parquet_dir}/interfaces_df.parquet
     filters:
       # filters common across all PDB datasets
       - "deposition_date < '2021-09-30'"


### PR DESCRIPTION
Change interfaces_df_train.parquet to interfaces_df.parquet in models/rfd3/configs/datasets/train/pdb/af3_train_interface.yaml to match the file names downloaded by `atomworks setup metadata` This fixes a FileNotFoundError when running `uv run python models/rfd3/src/rfd3/train.py experiment=pretrain`.