### PR TITLE
import apply_symmetry_to_xyz_atomwise in inference_sampler

### DIFF
--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -13,10 +13,7 @@ from foundry.utils.rotation_augmentation import (
     uniform_random_rotation,
 )
 
-from rfd3.inference.symmetry.atom_array import (
-    FIXED_ENTITY_ID,
-    FIXED_TRANSFORM_ID
-)
+from rfd3.inference.symmetry.atom_array import FIXED_ENTITY_ID, FIXED_TRANSFORM_ID
 from rfd3.inference.symmetry.symmetry_utils import apply_symmetry_to_xyz_atomwise
 
 ranked_logger = RankedLogger(__name__, rank_zero_only=True)

--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -12,6 +12,12 @@ from foundry.utils.rotation_augmentation import (
     uniform_random_rotation,
 )
 
+from rfd3.inference.symmetry.atom_array import (
+    FIXED_ENTITY_ID,
+    FIXED_TRANSFORM_ID
+)
+from rfd3.inference.symmetry.symmetry_utils import apply_symmetry_to_xyz_atomwise
+
 ranked_logger = RankedLogger(__name__, rank_zero_only=True)
 
 


### PR DESCRIPTION
This pull request introduces new imports to the `inference_sampler.py` file, preparing the module to support symmetry operations during inference. These changes set up the codebase for future enhancements related to symmetry handling.

* Added imports for `FIXED_ENTITY_ID` and `FIXED_TRANSFORM_ID` from `atom_array`, and `apply_symmetry_to_xyz_atomwise` from `symmetry_utils` to enable symmetry-related functionality in inference workflows.