### PR TITLE
Import apply_symmetry_to_xyz_atomwise function

### DIFF
--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -12,6 +12,7 @@ from foundry.utils.rotation_augmentation import (
     rot_vec_mul,
     uniform_random_rotation,
 )
+from rfd3.inference.symmetry.symmetry_utils import apply_symmetry_to_xyz_atomwise
 
 ranked_logger = RankedLogger(__name__, rank_zero_only=True)
 


### PR DESCRIPTION
apply_symmetry_to_xyz_atomwise function used in line 361 (new 362) when generating symmetric protein, but not imported