### PR TITLE
Add extra: {} field in RFD3 inference config in notebook example

### DIFF
--- a/examples/ipd_design_pipeline_collab.ipynb
+++ b/examples/ipd_design_pipeline_collab.ipynb
@@ -133,6 +133,7 @@
     "config = RFD3InferenceConfig(\n",
     "    specification={\n",
     "        'length': 80,  # Generate 80-residue proteins\n",
+    "        'extra': {},   # Pass empty metadata\n",
     "    },\n",
     "    diffusion_batch_size=2,  # Generate 2 structures per batch\n",
     ")\n",


### PR DESCRIPTION
When running the notebook without it, I get an error. This small addition fixes it. The rest works smoothly