### PR TITLE
Fix/config path

### DIFF
--- a/models/rf3/src/rf3/cli.py
+++ b/models/rf3/src/rf3/cli.py
@@ -23,10 +23,19 @@ def fold(
         configure_minimal_inference_logging()
 
     # Find the RF3 configs directory relative to this file
-    # This file is at: models/rf3/src/rf3/cli.py
-    # Configs are at: models/rf3/configs/
-    rf3_package_dir = Path(__file__).parent.parent.parent  # Go up to models/rf3/
-    config_path = str(rf3_package_dir / "configs")
+    # In development: models/rf3/src/rf3/cli.py -> models/rf3/configs/
+    # When installed: site-packages/rf3/cli.py -> site-packages/rf3/configs/
+    rf3_file_dir = Path(__file__).parent
+
+    # Check if we're in installed mode (configs are sibling to this file)
+    # or development mode (configs are ../../../configs)
+    if (rf3_file_dir / "configs").exists():
+        # Installed mode
+        config_path = str(rf3_file_dir / "configs")
+    else:
+        # Development mode
+        rf3_package_dir = rf3_file_dir.parent.parent  # Go up to models/rf3/
+        config_path = str(rf3_package_dir / "configs")
 
     # Get all arguments
     args = ctx.params.get("args", []) + ctx.args

--- a/models/rf3/src/rf3/inference.py
+++ b/models/rf3/src/rf3/inference.py
@@ -20,6 +20,7 @@ _config_path = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "configs"
 )
 
+
 @hydra.main(
     config_path=_config_path,
     config_name="inference",

--- a/models/rf3/src/rf3/inference.py
+++ b/models/rf3/src/rf3/inference.py
@@ -16,8 +16,9 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
 load_dotenv(override=True)
 
-_config_path = os.path.join(os.environ["PROJECT_ROOT"], "models/rf3/configs")
-
+_config_path = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "configs"
+)
 
 @hydra.main(
     config_path=_config_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,11 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0"
+local-scheme = "no-local-version"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/foundry/version.py"
 tag-pattern = "^v(?P<version>.*)$"
-local-scheme = "no-local-version"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/foundry/utils/ddp.py
+++ b/src/foundry/utils/ddp.py
@@ -2,7 +2,7 @@ import logging
 
 import torch
 from beartype.typing import Any
-from lightning_fabric.utilities import rank_zero_only
+from lightning.fabric.utilities import rank_zero_only
 from lightning_utilities.core.rank_zero import rank_prefixed_message
 from omegaconf import DictConfig
 

--- a/src/foundry/utils/logging.py
+++ b/src/foundry/utils/logging.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import pandas as pd
 from beartype.typing import Any
-from lightning_fabric.utilities import rank_zero_only
+from lightning.fabric.utilities import rank_zero_only
 from omegaconf import DictConfig, OmegaConf
 from rich.console import Console
 from rich.syntax import Syntax


### PR DESCRIPTION
This PR updates the RF3 CLI to enable running RF3 from the command line when pip installed while also maintaining the ability to use the CLI with a dev installation. It uses the same pattern used for the same thing in RFD3. 