### PR TITLE
Docs: PPI tutorial updates, RF3 and MPNN docs placeholders, minor edits

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ many of the machine learning models produced by `Rosetta Commons member labs <ht
    :caption: General
    
    license_link.rst
+   installation_faq.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,3 +21,5 @@ many of the machine learning models produced by `Rosetta Commons member labs <ht
    :caption: Models
 
    models/rfd3/index
+   models/rf3/index
+   models/mpnn/index

--- a/docs/source/installation_faq.md
+++ b/docs/source/installation_faq.md
@@ -1,0 +1,14 @@
+# Common Installation Issues
+
+<details>
+    <summary><strong>Installation on NVIDIA GeForce RTX 5060 - Blackwell architecture</strong></summary>
+    Taken from [Issue #105](https://github.com/RosettaCommons/foundry/issues/105):
+    If, when installing any of the models included in foundry, you get an error related to CUDA (see linked issue for examples) try installing a version of torch, torchvision and torchaudio that matches your python and CUDA distribution. For CUDA, choose the next lowest available library if there is not a version that matches your exact CUDA build. 
+
+    For example: 
+    ```
+    pip install torch==2.9.1+cu128 torchvision==0.24.1+cu128 torchaudio==2.9.1+cu128 --extra-index-url https://download.pytorch.org/whl/cu128
+    ```
+    This is for Python 2.9.1 and CUDA 12.8.
+
+</details>

--- a/docs/source/models/mpnn
+++ b/docs/source/models/mpnn
@@ -1,0 +1,1 @@
+../../../models/mpnn/docs

--- a/docs/source/models/rf3
+++ b/docs/source/models/rf3
@@ -1,0 +1,1 @@
+../../../models/rf3/docs

--- a/models/mpnn/docs/index.md
+++ b/models/mpnn/docs/index.md
@@ -1,0 +1,22 @@
+# MPNN Documentation
+
+```{warning}
+The documentation for the MPNN model is currently incomplete.
+If you would like to contribute, feel free to open a PR. 
+```
+```{warning}
+The MPNN model is still being benchmarked for comparison to the 
+original ProteinMPNN, LigandMPNN, and SolubleMPNN implementations.
+```
+
+The MPNN model in [foundry](https://github.com/RosettaCommons/foundry)
+has all of the functionality of [ProteinMPNN](https://www.science.org/doi/10.1126/science.add2187), 
+[LigandMPNN](https://www.nature.com/articles/s41592-025-02626-1), 
+and [SolubleMPNN](https://www.nature.com/articles/s41586-024-07601-y), 
+but with the backend support of [atomworks](https://github.com/RosettaCommons/atomworks) and 
+[foundry](https://github.com/RosettaCommons/foundry). More MPNN
+models and weights will be added to foundry in the future. 
+
+Are we missing a model you would like to work with? Create a PR with the 
+necessary files and/or code changes or open an issue requesting it.
+

--- a/models/rf3/docs/index.md
+++ b/models/rf3/docs/index.md
@@ -1,0 +1,11 @@
+# RF3 Documentation
+
+```{warning}
+The documentation for RF3 is currently incomplete. If you would like
+to contribute, feel free to open a PR!
+```
+
+RF3 is an all-atom biomolecular structure prediction network 
+competitive with leading open-source models. By including additional features at train-time – implicit chirality representations and atom-level geometric conditioning – we improve performance on tasks such as prediction of chiral ligands and fixed-backbone or fixed-conformer docking.
+
+For more information, please see our preprint, [Accelerating Biomolecular Modeling with AtomWorks and RF3](https://doi.org/10.1101/2025.08.14.670328).

--- a/models/rfd3/README.md
+++ b/models/rfd3/README.md
@@ -11,34 +11,49 @@ both are described in more detail below.
 </p>
 
 > [!NOTE]
-> Looking for config documentation? See [here](./docs/input.md)
+> Looking for information about configuration options? See a through list of possible inputs in our [external documentation](https://rosettacommons.github.io/foundry/models/rfd3/input.html).
 
 ## Getting Started
-1. Install RFdiffusion3. See [Main README](../../README.md) for instructions how to install all models to run full pipeline (recommended). If you have already installed all the models skip [here](#run-inference).
-```bash
-pip install rc-foundry[rfd3]
-```
+1. Install RFdiffusion3. 
+  If you have already installed all the models and **are not** interested in hydrogen bond conditioning skip [here](#running-inference). <br><br>
+  If you have already installed all the models and **are** interested in hydrogen bond conditioning skip [here](#hydrogen-bond-conditioning)
+  If you would like to install all of the foundry models (recommended), see the [foundry README](../../README.md) for instructions. <br><br>
+  If you would like to install only RFD3: 
+    ```bash
+    pip install rc-foundry[rfd3]
+    ```
+
 2. Download checkpoint to your desired checkpoint location.
-```bash
-foundry install rfd3 --checkpoint-dir <path/to/ckpt/dir>
-```
-This sets `FOUNDRY_CHECKPOINT_DIRS` and will in future look for checkpoints in that directory (alongside the default `~/.foundry/checkpoints` location), allowing you to run inference without supplying the checkpoint path. The checkpoint directory is optional, defaulting to `~/.foundry/checkpoints` if unset.
+    ```bash
+    foundry install rfd3 --checkpoint-dir <path/to/ckpt/dir>
+    ```
+    This sets `FOUNDRY_CHECKPOINT_DIRS` and will in future look for checkpoints in that directory (alongside the default `~/.foundry/checkpoints` location), allowing you to run inference without supplying the checkpoint path. The checkpoint directory is optional, defaulting to `~/.foundry/checkpoints` if unset.
+
+### Hydrogen Bond Conditioning
+If you would like to use hydrogen bond conditioning in your designs, 
+you need to install [HBPLUS](https://www.ebi.ac.uk/thornton-srv/software/HBPLUS/). This is **not** installed by default:
+
+3. Download HBPLUS from here: https://www.ebi.ac.uk/thornton-srv/software/HBPLUS/download.html (available for free)
+4. Follow the installation instruction here: https://www.ebi.ac.uk/thornton-srv/software/HBPLUS/install.html
+5. Update `HBPLUS_PATH` in `foundry/.env` file with the path to your `hbplus` executable.
 
 ## Running Inference
+
+Below is a quick inference example to run to test that your setup
+is working correctly. If you are new to RFdiffusion methods or JSON/YAML structure, we recommend that you follow the [PPI tutorial](https://rosettacommons.github.io/foundry/models/rfd3/ppi_design_tutorial.html) to set up your first calculation.
 
 To run inference (with foundry installed in your environment, or RFD3 & Foundry src in PYTHONPATH):
 ```bash
 rfd3 design out_dir=logs/inference_outs/demo/0 inputs=models/rfd3/docs/demo.json skip_existing=False dump_trajectories=True prevalidate_inputs=True
 ```
+To run RFD3, you only need to provide the input (`inputs`) JSON/YAML file (see the [external documentation for more details](https://rosettacommons.github.io/foundry/models/rfd3/index.html#general)) where you specify your design constraints and the output directory (`out_dir`) where you want to store the files RFD3 generates.
 
-Additional unnecessary args here are added:
-- Including dumping and aligning trajectory structures can be useful for debugging your setup or making cool gifs.
-- Printing the config and dumping trajectories are turned off by default, but turned on here for verbosity
-- `prevalidate_inputs` will check that your inputs are valid before running inference. Helpful if your json has a number of different configs you want to debug / double check are valid before loading the checkpoints.
-- Only `out_dir` and `inputs` are required. The output directory will automatically be created. 
+Additional unnecessary (but useful!) options are added to the above command:
+- `dump_trajectories`: Dumps trajectory structures, can be useful for debugging your setup or making cool gifs. However, trajectory files are large, thus this setting is False by default.
+- `prevalidate_inputs`: Checks that your inputs are valid before running inference. Helpful if your JSON/YAML has a number of different configs you want to debug / double check are valid before loading the checkpoints.
+- `skip_existing`: Skips any existing files that would be in the same place and have the same name as the calculation being run. If you are testing your setup multiple times, including this option is important so that you actually run RFdiffusion3. 
 
-
-There are various interesting ways you can use RFD3 beyond Atom14 design as it's trained on a large array of different tasks.
+There are various interesting ways you can use RFD3 beyond [Atom14](https://www.biorxiv.org/content/10.1101/2024.08.16.608235v4) design as it's trained on a large array of different tasks.
 For example, you can fix sequence and not structure (prediction-type task), fix the backbone and unfix the sequence (MPNN-type inverse folding) or unfix the sidechains only (PLACER/ChemNet-style):
 
 <p align="center">
@@ -47,7 +62,7 @@ For example, you can fix sequence and not structure (prediction-type task), fix 
 
 For full details on how to specify inputs, see the [input specification documentation](./docs/input.md). You can also see `foundry/models/rfd3/configs/inference_engine/rfdiffusion3.yaml` for even more options.
 
-## Further example jsons for different applications
+## Further example JSONs for different applications
 Additional examples are broken up by use case. If you have cloned the
 repository, matching `.json` files are in `foundry/models/rfd3/docs`
 that can be run directly, similar to the previous example. 

--- a/models/rfd3/docs/enzyme_design.md
+++ b/models/rfd3/docs/enzyme_design.md
@@ -9,7 +9,7 @@ RFD3 contains several knobs and dials for enzyme design.
 If you would like to run the examples below, `enzyme_design.json`, located in this directory, contains the example code. You can run it via:
 ```
 rfd3 design out_dir=inference_outputs/enzyme/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./enzyme_design.json
 ```
 
@@ -17,7 +17,7 @@ Or, if you have cloned the repo rather than using `pip install`:
 ```
 python path/to/foundry/models/rfd3/src/rfd3/run_inference.py \
 out_dir=inference_outputs/enzyme/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./enzyme_design.json 
 ```
 

--- a/models/rfd3/docs/input.md
+++ b/models/rfd3/docs/input.md
@@ -88,9 +88,9 @@ rfd3 design out_dir=<path/to/outdir> inputs=<path/to/inputs>
     - `all` — (default) Uses the center of mass (COM) of all atoms
     - `motif` — Uses the COM of the motif atoms with fixed coordinates
     - `diffuse` — Uses the COM of all fixed coordinates that are not part of motif atoms
-  - `s_trans` — Translational noise scale for augmentation during inference (default: 1.0).
+  - `s_trans` — Translational noise scale for augmentation during inference (default: 1.0). 
   <!-- `inference_noise_scaling_factor` As far as I can tell there isn't actually any code to make use of this setting -->
-  - `allow realignment` — If set to `True` (default: False) then the noised structure can be realigned during inference based on the location of a given motif.
+  - `allow_realignment` — If set to `True` (default: False) then the noised structure can be realigned during inference based on the location of a given motif. From [Issue #154](https://github.com/RosettaCommons/foundry/issues/154): It is generally not needed to include this option, there are fewer 'weird' interactions with motif scaffolding when it's set to False.
   - `noise_scale` — This parameter sets the scaling for the noise during inference (default 1.003). A smaller value will lead to less noise in your system leading to less diversity in the outputs. 
   - `p` — Determines the 'shape' of the noise schedule (default: 7).
   - `gamma_0` — This value (default: 0.6) influences the diversity of the designs from RFD3. A lower value increases designability but decreases diversity. 
@@ -137,7 +137,7 @@ Below is a table of all of the inputs that the `InputSpecification` accepts. Use
 | `ori_token`                                                    | `list[float]`     | `[x,y,z]` origin override to control COM (center of mass) placement of designed structure. |
 | `infer_ori_strategy`                                           | `str`             | `"com"` or `"hotspots"`.  The center of mass of the diffused region will typically be within 5Å of the ORI token. Using `hotspots` will place the ORI token 10Å outward from the center of mass of the specified hotspots. Using `com` will place the token at the center of mass of the input structure.|
 | `plddt_enhanced`                                               | `bool`            | Default `True`. Enables pLDDT (predicted Local Distance Difference Test) enhancement. |
-| `is_non_loopy`                                                 | `bool`            | Default `True`. Produces output structures with fewer loops.|
+| `is_non_loopy`                                                 | `bool`            | Default `None`. Produces output structures with fewer loops if set to True. |
 | `partial_t`                                                    | `float`           | Noise (Å) for partial diffusion, enables partial diffusion (sets the noise level.) Recommended values are 5.0-15.0 Å. See [Partial Diffusion](#partial-diffusion) for more information. |
 
 
@@ -209,10 +209,14 @@ my_calculation:
 
 (unindexing-specifics)=
 ### Unindexing Specifics
+```{note}
+Unindexed atoms are **always** fixed unless otherwise specified in the `select_fixed_atoms` option. At least one atom in any unidexed residue needs to be fixed.
+```
 
-`unindex` marks motif tokens whose relative sequence placement is unknown to the model (useful for scaffolding around active sites, etc.).
-Use a string to list the unindexed components and where breaks occur.
-Use a dictionary if you want to fix specific atoms of those residues; atoms not fixed are not copied from the input (they will be diffused).
+`unindex` marks motif tokens whose relative sequence placement is unknown to the model (useful for scaffolding around active sites, etc.). 
+To specify the unindexed regions of your design you can: 
+- Use a string to list the unindexed components and where breaks occur.
+- Use a dictionary if you want to fix specific atoms of those residues; atoms not fixed are not copied from the input (they will be diffused).
 Breaks between unindexed components follow the contig conventions you’re used to. For example: `"A244,A274,A320,A329,A375"` lists multiple unindexed components; internal “breakpoints” are inferred and logged. (Offset syntax like `A11-12` or `A11,0,A12` still ties residues.)
 You can specify consecutive residues as e.g. `A11-12` (instead of `A11,A12`), this will tie the two components together in sequence (or at least it leaks to the model that residues are together in sequence). 
 Similarly, you can specify manually any number of residues that offsets two components, e.g. `A11,0,A12` (0 sequence offset, equivalent to just `A11-12`), or `A11,3,A12` (3-residue separation).
@@ -220,8 +224,13 @@ From our initial tests this only leads to a slight bias in the model, but newer 
 
 (partial-diffusion)=
 ### Partial Diffusion
+
+```{important}
+Partial diffusion (`partial_t`) does *not* directly change the number of timesteps reversed during the inference process. It sets the standard deviation of the noise added back. This value is nonlinear, so it is recommended to start with a relatively small value (2Å) and gradually raise it. 
+```
+
 To enable partial diffusion, you can pass `partial_t` with any example. This sets the *noise level* in *angstroms* for the sampler:
-- The `specification.partial_t` argument can be specified from JSON or the command line.
+- The `specification.partial_t` argument can be specified from your JSON/YAML input file
 - Partial diffusion will fix/unfix ligands and nucleic acids as normal, by default it will fix non-protein components and they must be specified explicitly.
 - By default, the ca-aligned `ca_rmsd_to_input` will be logged.
 - Currently, partial diffusion subsets the inference schedule based on the partial_t, so `inference_sampler.num_timesteps` will affect how many steps are used but it is not equal to the number of steps used.

--- a/models/rfd3/docs/na_binder_design.md
+++ b/models/rfd3/docs/na_binder_design.md
@@ -3,7 +3,7 @@
 If you would like to run the examples below, `na_binder_design.json`, located in this directory, contains the example code. You can run it via:
 ```
 rfd3 design out_dir=inference_outputs/na_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./na_binder_design.json
 ```
 
@@ -11,7 +11,7 @@ Or, if you have cloned the repo rather than using `pip install`:
 ```
 python path/to/foundry/models/rfd3/src/rfd3/run_inference.py \
 out_dir=inference_outputs/na_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./na_binder_design.json 
 ```
 

--- a/models/rfd3/docs/protein_binder_design.md
+++ b/models/rfd3/docs/protein_binder_design.md
@@ -15,7 +15,7 @@ designs, which greatly increases PPI designability.
 If you would like to run the examples below, `protein_binder_design.json`, located in this directory, contains the example code. You can run it via:
 ```
 rfd3 design out_dir=inference_outputs/protein_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./protein_binder_design.json \
 inference_sampler.step_scale=3 \
 inference_sampler.gamma_0=0.2
@@ -25,7 +25,7 @@ Or, if you have cloned the repo rather than using `pip install`:
 ```
 python path/to/foundry/models/rfd3/src/rfd3/run_inference.py \
 out_dir=inference_outputs/protein_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./protein_binder_design.json \
 inference_sampler.step_scale=3 \
 inference_sampler.gamma_0=0.2

--- a/models/rfd3/docs/sm_binder_design.md
+++ b/models/rfd3/docs/sm_binder_design.md
@@ -3,7 +3,7 @@
 If you would like to run the examples below, `sm_binder_design.json`, located in this directory, contains the example code. You can run it via:
 ```
 rfd3 design out_dir=inference_outputs/sm_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./sm_binder_design.json
 ```
 
@@ -11,7 +11,7 @@ Or, if you have cloned the repo rather than using `pip install`:
 ```
 python path/to/foundry/models/rfd3/src/rfd3/run_inference.py \
 out_dir=inference_outputs/sm_binder/0 \
-ckpt_path=/path/to/rfd3_foundry_2025_12_01.ckpt \
+ckpt_path=/path/to/rfd3_latest.ckpt \
 inputs=./sm_binder_design.json 
 ```
 


### PR DESCRIPTION
This PR:
- makes minor edits to several documentation files to clean up and clarify language. 
- Creates locations for the MPNN and RF3 documentation in the external docs and sets up the required symlinks to have sphinx work
- Updates the PPI tutorial to point to other important resources and fixes a few typos. 