### PR TITLE
fix: restore python version constraint (==3.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "rc-foundry"
 dynamic = ["version"]
 description = "Shared utilities and training infrastructure for biomolecular structure prediction models."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "==3.12"
 authors = [
     { name = "Institute for Protein Design", email = "contact@ipd.uw.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "rc-foundry"
 dynamic = ["version"]
 description = "Shared utilities and training infrastructure for biomolecular structure prediction models."
 readme = "README.md"
-requires-python = "==3.12"
+requires-python = ">=3.12,<3.13"
 authors = [
     { name = "Institute for Protein Design", email = "contact@ipd.uw.edu" },
 ]


### PR DESCRIPTION
Commit 49187c3 unintentionally reverted requires-python from ==3.12 back to >=3.12 as a side-effect of the inference fix. This restores the version constraint originally introduced in 8aeacba.