### PR TITLE
fix: bf16 precision failures in attention index construction for large inputs

### DIFF
--- a/models/rfd3/src/rfd3/model/layers/block_utils.py
+++ b/models/rfd3/src/rfd3/model/layers/block_utils.py
@@ -404,22 +404,26 @@ def extend_index_mask_with_neighbours(
     k = min(k, L)
     assert mask.shape == (L, L) and D_LL.shape == (B, L, L)
     device = D_LL.device
-    inf = torch.tensor(float("inf"), dtype=D_LL.dtype, device=device)
+    # float32 sentinel for index arithmetic: bfloat16/float16 cannot exactly represent
+    # large integer indices (e.g. bfloat16 loses precision above ~256), so we keep
+    # the index tensor in float32 regardless of D_LL.dtype to avoid spurious duplicates.
+    inf_idx = torch.tensor(float("inf"), dtype=torch.float32, device=device)
+    inf_dist = torch.tensor(float("inf"), dtype=D_LL.dtype, device=device)
 
     # 1. Selection of sequence neighbours
-    all_idx_row = torch.arange(L, device=device).expand(L, L)
-    indices = torch.where(mask, all_idx_row, inf)  # sentinel inf if not-forced
-    indices = indices.sort(dim=1)[0][:, :k]  # (L, k)
+    all_idx_row = torch.arange(L, device=device, dtype=torch.float32).expand(L, L)
+    indices = torch.where(mask, all_idx_row, inf_idx)  # sentinel inf if not-forced
+    indices = indices.sort(dim=1)[0][:, :k]  # (L, k) float32 — exact for any practical L
 
     # 2. Find k-nn excluding forced indices
-    D_LL = torch.where(mask, inf, D_LL)
+    D_LL = torch.where(mask, inf_dist, D_LL)
     filler_idx = torch.topk(D_LL, k, dim=-1, largest=False).indices
 
     # ... Reverse last axis s.t. best matched indices are last
     filler_idx = filler_idx.flip(dims=[-1])
 
     # 3. Fill indices
-    to_fill = indices == inf
+    to_fill = indices == inf_idx
     to_fill = to_fill.expand_as(filler_idx)
     indices = indices.expand_as(filler_idx)
     indices = torch.where(to_fill, filler_idx, indices)

--- a/models/rfd3/src/rfd3/model/layers/block_utils.py
+++ b/models/rfd3/src/rfd3/model/layers/block_utils.py
@@ -196,7 +196,7 @@ def create_attention_indices(
         X_L = torch.randn(
             (1, L, 3), device=device, dtype=torch.float
         )  # [L, 3] - random
-    D_LL = torch.cdist(X_L, X_L, p=2)  # [B, L, L] - pairwise atom distances
+    D_LL = torch.cdist(X_L.float(), X_L.float(), p=2)  # [B, L, L] - always float32: bfloat16 quantises distances severely at large t, causing topk ties and duplicate attention indices
 
     # Create attention indices using neighbour distances
     base_mask = ~f["unindexing_pair_mask"][

--- a/models/rfd3/src/rfd3/model/layers/block_utils.py
+++ b/models/rfd3/src/rfd3/model/layers/block_utils.py
@@ -197,6 +197,7 @@ def create_attention_indices(
             (1, L, 3), device=device, dtype=torch.float
         )  # [L, 3] - random
     D_LL = torch.cdist(X_L.float(), X_L.float(), p=2)  # [B, L, L] - always float32: bfloat16 quantises distances severely at large t, causing topk ties and duplicate attention indices
+    D_LL = D_LL.nan_to_num(nan=1e8)  # bfloat16 overflow at high noise t produces NaN coords → NaN distances → topk undefined behaviour → duplicate indices
 
     # Create attention indices using neighbour distances
     base_mask = ~f["unindexing_pair_mask"][


### PR DESCRIPTION
Fixes three related bugs that cause a duplicate-index assertion in get_sparse_attention_indices when training with
bfloat16 AMP on large inputs or at high diffusion noise timesteps. 
                                                                                                                            
Bug 1 – Index precision loss for L > 2048 (81175fa)                                                                       
The index sentinel tensor inherited dtype from D_LL, which is bfloat16 under AMP. bfloat16 can only represent integers
exactly up to ~256, so indices ≥ 2048 alias to the same value, producing guaranteed collisions in the sort-based mask     
logic.          
Fix: keep the index tensor in float32 regardless of D_LL.dtype.                                                           
                                                                                                                            
Bug 2 – Distance quantization at high noise (b37674d)                                                                     
bfloat16 has a step size of ~16 in the 2048–4096 Å range. At high diffusion noise levels, atom coordinates can reach this 
range, causing massive ties in D_LL. CUDA topk tie-breaking is non-deterministic and returns non-unique indices.          
Fix: cast X_L to float32 before cdist.
                                                                                                                            
Bug 3 – NaN propagation at maximum noise (c6adeaa)                                                                        
At the maximum noise level, bfloat16 overflow can produce NaN coordinates in X_L, which propagate through cdist. topk on
NaN inputs has undefined CUDA behaviour and returns duplicate indices.                                                    
Fix: nan_to_num(nan=1e8) after cdist to replace NaNs with a large finite sentinel.