### PR TITLE
Adding Google Analytics to the Foundry documentation

### DIFF
--- a/docs/source/_static/ga.js
+++ b/docs/source/_static/ga.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-6Q7T573HLF');

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,3 +57,8 @@ source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
     }
+
+html_js_files = [
+    'https://www.googletagmanager.com/gtag/js?id=G-6Q7T573HLF',
+    'ga.js',
+]


### PR DESCRIPTION
The analytics are under Rachel Clune's OSMF account and will only be used for reporting to the Rosetta Commons Board