### PR TITLE
Optimize attention computation with local window bias

### DIFF
--- a/models/rf3/src/rf3/model/layers/af3_diffusion_transformer.py
+++ b/models/rf3/src/rf3/model/layers/af3_diffusion_transformer.py
@@ -499,7 +499,6 @@ class AttentionPairBiasDiffusion(nn.Module):
         Q_IH = self.to_q(A_I)
         K_IH = self.to_k(A_I)
         V_IH = self.to_v(A_I)
-        B_IIH = self.to_b(self.ln_0(Z_II))
         G_IH = self.to_g(A_I)
 
         if self.kq_norm:
@@ -523,12 +522,18 @@ class AttentionPairBiasDiffusion(nn.Module):
         maskK = (indicesK < 0) | (indicesK > L - 1)
         indicesK = torch.clamp(indicesK, 0, L - 1)
 
+        # Compute pair bias within local windows only, to avoid applying
+        # LayerNorm to the full [1, L, L, c_pair] tensor which can exceed
+        # 2^32 elements for large systems and silently corrupt CUDA outputs.
+        Z_local = Z_II[:, indicesQ[:, :, None], indicesK[:, None, :]]
+        B_local = self.to_b(self.ln_0(Z_local))
+
         query_subset = Q_IH[:, indicesQ]
         key_subset = K_IH[:, indicesK]
         attn = torch.einsum("...ihd,...jhd->...ijh", query_subset, key_subset)
         attn = attn / (self.c**0.5)
 
-        attn += B_IIH[:, indicesQ[:, :, None], indicesK[:, None, :]] - 1e9 * (
+        attn += B_local - 1e9 * (
             maskQ[None, :, :, None, None] + maskK[None, :, None, :, None]
         )
         attn = torch.softmax(attn, dim=-2)


### PR DESCRIPTION
Refactor attention mechanism to compute pair bias within local windows, avoiding large tensor operations. 

For systems with >16,384 atoms RF3 produces partially unphysical structures. 

In `AttentionPairBiasDiffusion.atom_attention()`, the pair representation tensor is processed as:
```python
B_IIH = self.to_b(self.ln_0(Z_II))  # Z_II shape: [1, L, L, 16]
```

For large systems the number of elements in Z_II exceeds 2^32. (At least in some versions) PyTorch's CUDA `nn.LayerNorm` kernel uses 32-bit unsigned integer offsets internally. Which causes corrupt output if the number of elements is > 2^32.

The fix gathers the local Z_II window before applying the LayerNorm, instead of computing self.to_b(self.ln_0(Z_II)) on the full [1, L, L, 16] tensor and then indexing into it. This is mathematically identical (LayerNorm normalizes over the last dimension independently per position), but keeps the tensor size to [1, nqbatch, 32, 128, 16] 

This fixes #238 and saves a fair amount of GPU RAM because the full B_IIH is never materialized.