### PR TITLE
Run weighted_rigid_align's Kabsch SVD in float32 (fix bf16 crash)

### DIFF
--- a/src/foundry/utils/alignment.py
+++ b/src/foundry/utils/alignment.py
@@ -57,7 +57,9 @@ def weighted_rigid_align(
     # Computation of the covariance matrix
     C = torch.einsum("bji,bjk->bik", w_resolved[..., None] * X_gt_resolved, X_resolved)
 
-    U, S, V = torch.linalg.svd(C)
+    # SVD has no bf16/half CUDA kernel and is numerically sensitive; compute the
+    # rotation in float32 and cast it back to the input dtype below.
+    U, S, V = torch.linalg.svd(C.float())
 
     R = U @ V
     B, _, _ = X_L.shape
@@ -71,7 +73,7 @@ def weighted_rigid_align(
 
     det = torch.linalg.det(R)
     F[..., -1, -1] = torch.sign(det)
-    R = U @ F @ V
+    R = (U @ F @ V).to(X_gt_L.dtype)
 
     X_gt_L = X_gt_L - u_X_gt.unsqueeze(-2)
     X_align_L = X_gt_L @ R + u_X.unsqueeze(-2)


### PR DESCRIPTION
## Problem

`foundry/utils/alignment.py::weighted_rigid_align` runs `torch.linalg.svd(C)` directly on the covariance matrix. When the model runs in **bfloat16** (the default rf3 inference dtype) `C` is bf16, and PyTorch has **no SVD kernel for bf16/half** (neither CUDA `gesvdjBatched` nor the CPU path). So any bf16 caller that reaches this alignment crashes:

```
RuntimeError: "svd_cuda_gesvdjBatched" not implemented for 'BFloat16'
```

In practice this hits **rf3 motif scaffolding with realignment** (`inference_sampler.center_option=motif`, `allow_realignment=True`), which dies at the first realignment step and produces 0 designs.

## Fix

Compute the SVD/rotation in **float32** (CUDA-supported, and SVD is numerically sensitive regardless), then cast the rotation back to the input dtype:

```python
U, S, V = torch.linalg.svd(C.float())
...
R = (U @ F @ V).to(X_gt_L.dtype)
```

Two-line change; no effect on fp32 callers.

## Verification

Ran the real `weighted_rigid_align` on a bf16 input (a small point set rotated by a known transform):
- **before:** `RuntimeError: ... svd ... not implemented for 'BFloat16'`
- **after:** succeeds; output dtype preserved (`bfloat16`); recovered alignment RMSD ≈ 0 vs the known rigid transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)