### PR TITLE
test: bootstrap mypy + pytest + coverage CI gates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,7 @@ on:
   # Run on every pull request regardless of base branch, so stacked task-branch PRs
   # are gated too (not just PRs targeting the mainline branches above).
   pull_request:
-  pull_request_target:
-    types: [ready_for_review]
+ 
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: test
+
+on:
+  push:
+    branches: [main, production, wip/for-release, wip/remove-chemdata]
+  pull_request:
+    branches: [main, production, wip/for-release, wip/remove-chemdata]
+  pull_request_target:
+    types: [ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    name: mypy (type check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - name: Install package + dev extras
+        # `[dev]` pulls in mypy and the dev tooling. The package itself is needed
+        # so mypy can resolve `import foundry.*` against the installed source.
+        run: pip install -e ".[dev]"
+      - name: mypy
+        run: mypy
+
+  pytest:
+    name: pytest (top-level tests/)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - name: Install package + dev extras
+        run: pip install -e ".[dev]"
+      - name: pytest
+        # Top-level tests/ only. Per-model tests under models/*/tests/ may require
+        # GPU and downloaded checkpoints and are not yet wired into CI.
+        run: pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,9 @@ name: test
 on:
   push:
     branches: [main, production, wip/for-release, wip/remove-chemdata]
+  # Run on every pull request regardless of base branch, so stacked task-branch PRs
+  # are gated too (not just PRs targeting the mainline branches above).
   pull_request:
-    branches: [main, production, wip/for-release, wip/remove-chemdata]
   pull_request_target:
     types: [ready_for_review]
   workflow_dispatch:

--- a/models/rfd3/src/rfd3/inference/input_parsing.py
+++ b/models/rfd3/src/rfd3/inference/input_parsing.py
@@ -778,9 +778,7 @@ class DesignInputSpecification(BaseModel):
                 if is_motif.any() and (~is_motif).any():
                     diffused_coord = atom_array.coord[~is_motif]
                     finite = np.isfinite(diffused_coord).all(axis=-1)
-                    center = np.nan_to_num(
-                        np.mean(diffused_coord[finite], axis=0)
-                    )
+                    center = np.nan_to_num(np.mean(diffused_coord[finite], axis=0))
                     atom_array.coord = atom_array.coord - center
                     logger.info(
                         f"Partial diffusion: centering on diffused-region COM ({center})."

--- a/models/rfd3/tests/test_partial_diffusion.py
+++ b/models/rfd3/tests/test_partial_diffusion.py
@@ -58,12 +58,12 @@ def test_partial_diffusion_respects_ori_token():
     delta = aa_shift.coord.mean(axis=0) - aa_default.coord.mean(axis=0)
     # Coords are translated by -ori_token at parse time, so the post-parse
     # whole-structure mean must drop by ~50 Å on x.
-    assert delta[0] == pytest.approx(-50.0, abs=1.5), (
-        f"ori_token=[50,0,0] should shift coords by -50 in x; got delta={delta}"
-    )
-    assert abs(delta[1]) < 1.5 and abs(delta[2]) < 1.5, (
-        f"ori_token=[50,0,0] should not move y/z; got delta={delta}"
-    )
+    assert delta[0] == pytest.approx(
+        -50.0, abs=1.5
+    ), f"ori_token=[50,0,0] should shift coords by -50 in x; got delta={delta}"
+    assert (
+        abs(delta[1]) < 1.5 and abs(delta[2]) < 1.5
+    ), f"ori_token=[50,0,0] should not move y/z; got delta={delta}"
 
 
 @pytest.mark.fast
@@ -86,9 +86,9 @@ def test_partial_diffusion_defaults_to_diffused_region_com():
         pytest.skip("Test fixture has no separable motif/diffused split")
 
     diffused_com = aa.coord[~is_motif].mean(axis=0)
-    assert np.allclose(diffused_com, 0, atol=1e-3), (
-        f"diffused-region COM should be at origin after centering; got {diffused_com}"
-    )
+    assert np.allclose(
+        diffused_com, 0, atol=1e-3
+    ), f"diffused-region COM should be at origin after centering; got {diffused_com}"
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ dev = [
     "assertpy",
     "ruff==0.8.3",
     "ipdb",
+    # Type checking
+    "mypy>=1.13,<2",
     # Debugger/interactive
     "debugpy>=1.8.5,<2",
     "ipykernel>=6.29.4,<7",
@@ -200,6 +202,53 @@ ignore = [
 
 [tool.pyright]
 typeCheckingMode = "off"
+
+# Type checking ----------------------------------------------------------------------
+# Lenient baseline so the existing largely-unannotated code does not fail the gate.
+# Per-module strictness is ratcheted up via [tool.mypy.overrides] as annotations land.
+[tool.mypy]
+python_version = "3.12"
+files = ["src/foundry", "src/foundry_cli"]
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+disallow_untyped_defs = false
+check_untyped_defs = false
+
+# Modules with pre-existing type errors at bootstrap time. These are the track-1
+# ratchet list — fix the errors and remove the entry to enable type-checking for
+# that module. Do NOT add modules to this list; only remove from it.
+[[tool.mypy.overrides]]
+module = [
+    "foundry.callbacks.health_logging",
+    "foundry.callbacks.metrics_logging",
+    "foundry.callbacks.train_logging",
+    "foundry.common",
+    "foundry.hydra.resolvers",
+    "foundry.inference_engines.base",
+    "foundry.metrics.metric",
+    "foundry.trainers.fabric",
+    "foundry.utils.components",
+    "foundry.utils.datasets",
+    "foundry.utils.ddp",
+    "foundry.utils.rigid",
+    "foundry.utils.weights",
+    "foundry_cli.download_checkpoints",
+]
+ignore_errors = true
+
+# Testing ----------------------------------------------------------------------------
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers --strict-config"
+
+[tool.coverage.run]
+source = ["src/foundry", "src/foundry_cli"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,12 +227,16 @@ module = [
     "foundry.hydra.resolvers",
     "foundry.inference_engines.base",
     "foundry.metrics.metric",
+    "foundry.model.layers.blocks",
     "foundry.trainers.fabric",
+    "foundry.training.schedulers",
     "foundry.utils.components",
     "foundry.utils.datasets",
     "foundry.utils.ddp",
+    "foundry.utils.logging",
     "foundry.utils.rigid",
     "foundry.utils.weights",
+    "foundry.utils.xpu.xpu_accelerator",
     "foundry_cli.download_checkpoints",
 ]
 ignore_errors = true


### PR DESCRIPTION
## What

Wire up the CI gate that the project's test and type-checking work lands against.

- `pyproject.toml` — add `mypy>=1.13` to `[dev]`; a lenient `[tool.mypy]` scoped to `src/foundry` + `src/foundry_cli`; `[[tool.mypy.overrides]] ignore_errors = true` for the 18 modules with pre-existing type errors (an explicit list — fix and remove, never add); `[tool.pytest.ini_options]` (`testpaths = ["tests"]`, `--strict-markers --strict-config`); `[tool.coverage.*]` for opt-in gap finding.
- `.github/workflows/test.yaml` — new workflow with `mypy` and `pytest` jobs. Runs on every pull request (any base branch) plus pushes to the mainline branches. Top-level `tests/` only; per-model tests under `models/*/tests/` need GPU/checkpoints and stay out of CI for now.

## Why

To increase the project's test coverage and keep it from regressing. The codebase currently has almost no automated tests or type checking, and nothing in CI enforcing them. This PR adds that gate — mypy and pytest running on every change — so unit tests, type annotations, and integration tests can be added against it and verified on every PR.

## Reviewer notes

- The 18-module `ignore_errors` list is intentional: without it, mypy reports ~180 pre-existing errors across already-annotated `src/foundry` code. These are fixed incrementally in follow-up PRs (the list only shrinks, never grows); the inline comment in `pyproject.toml` documents the contract.
- Commit `91781c5` ("ruff format 2 pre-existing files") is a pure `ruff format` pass — **no code or logic changes**. It is included only because those two files were merged unformatted and were blocking the `lint_production` workflow.
- First run of the `test` workflow: if `pip install -e ".[dev]"` fails on a wheel build (`atomworks[openbabel]` sometimes needs system C++ deps on a fresh runner), expect a follow-up to add `apt-get install` steps.
- `testpaths = ["tests"]` changes bare `pytest` at the repo root: it no longer auto-discovers `models/*/tests/`. Run those by passing the path explicitly.
