### PR TITLE
refactor(mypy): un-ignore 7 medium-tier modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,11 +221,6 @@ check_untyped_defs = false
 [[tool.mypy.overrides]]
 module = [
     "foundry.callbacks.health_logging",
-    "foundry.callbacks.metrics_logging",
-    "foundry.callbacks.train_logging",
-    "foundry.common",
-    "foundry.hydra.resolvers",
-    "foundry.inference_engines.base",
     "foundry.metrics.metric",
     "foundry.model.layers.blocks",
     "foundry.trainers.fabric",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,17 +222,10 @@ check_untyped_defs = false
 module = [
     "foundry.callbacks.health_logging",
     "foundry.metrics.metric",
-    "foundry.model.layers.blocks",
     "foundry.trainers.fabric",
-    "foundry.training.schedulers",
-    "foundry.utils.components",
     "foundry.utils.datasets",
     "foundry.utils.ddp",
-    "foundry.utils.logging",
     "foundry.utils.rigid",
-    "foundry.utils.weights",
-    "foundry.utils.xpu.xpu_accelerator",
-    "foundry_cli.download_checkpoints",
 ]
 ignore_errors = true
 

--- a/src/foundry/callbacks/metrics_logging.py
+++ b/src/foundry/callbacks/metrics_logging.py
@@ -167,7 +167,7 @@ class StoreValidationMetricsInDFCallback(BaseCallback):
         files = list(self.save_dir.glob(pattern))
 
         # Track which example_id + dataset combinations we've already seen
-        seen_examples = set()
+        seen_examples: set[str] = set()
         final_dataframes = []
 
         for f in files:

--- a/src/foundry/callbacks/train_logging.py
+++ b/src/foundry/callbacks/train_logging.py
@@ -144,7 +144,7 @@ class LogAF3TrainingLossesCallback(BaseCallback):
         self.logger = RankedLogger(__name__, rank_zero_only=True)
 
         # This dict will store key -> MeanMetric() for each loss
-        self.loss_trackers = {}
+        self.loss_trackers: dict[str, MeanMetric] = {}
 
     def on_train_epoch_start(self, trainer):
         # Record the start time of the epoch

--- a/src/foundry/common.py
+++ b/src/foundry/common.py
@@ -19,7 +19,7 @@ def run_once(fn: Callable) -> Callable:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if getattr(wrapper, "_has_run", False):
             return
-        wrapper._has_run = True
+        setattr(wrapper, "_has_run", True)
         return fn(*args, **kwargs)
 
     return wrapper

--- a/src/foundry/hydra/resolvers.py
+++ b/src/foundry/hydra/resolvers.py
@@ -25,7 +25,7 @@ def register_resolvers():
         OmegaConf.register_new_resolver(name, resolver)
 
 
-def resolve_import(module_path: str, attribute_path: str = None) -> Any:
+def resolve_import(module_path: str, attribute_path: str | None = None) -> Any:
     """
     Import a module and access a specific attribute from it.
 

--- a/src/foundry/inference_engines/base.py
+++ b/src/foundry/inference_engines/base.py
@@ -102,7 +102,7 @@ class BaseInferenceEngine:
         self.transform_overrides = transform_overrides
         self.overrides: dict[str, Any] = {}
 
-        base_overrides = {
+        base_overrides: dict[str, Any] = {
             "trainer.seed": seed,
             "trainer.metrics": {},
             "trainer.loss": None,

--- a/src/foundry/model/layers/blocks.py
+++ b/src/foundry/model/layers/blocks.py
@@ -5,6 +5,11 @@ pi = torch.acos(torch.zeros(1)).item() * 2
 
 
 class FourierEmbedding(nn.Module):
+    # Declared so type checkers see the registered buffers as Tensors rather
+    # than nn.Module's Tensor | Module attribute fallback.
+    w: torch.Tensor
+    b: torch.Tensor
+
     def __init__(self, c):
         super().__init__()
         self.c = c

--- a/src/foundry/training/schedulers.py
+++ b/src/foundry/training/schedulers.py
@@ -74,7 +74,7 @@ class SchedulerConfig:
         frequency (int): The frequency of applying the scheduler. For example, a frequency of 1 means the scheduler is applied every epoch. Defaults to 1.
     """
 
-    scheduler: LRScheduler = None
+    scheduler: LRScheduler
     interval: str = "step"
     frequency: int = 1
 

--- a/src/foundry/utils/components.py
+++ b/src/foundry/utils/components.py
@@ -6,7 +6,6 @@ import numpy as np
 from atomworks.ml.encoding_definitions import AF3SequenceEncoding
 from biotite.structure import AtomArray
 
-from foundry.common import exists
 from foundry.constants import (
     TIP_BY_RESTYPE,
 )
@@ -278,17 +277,18 @@ def get_name_mask(
         elif query_names.upper() == "BKBN":
             names = ["N", "CA", "C", "O"]
         elif query_names.upper() == "TIP":
-            if not exists(source_resname):
+            if source_resname is None:
                 raise ComponentValidationError(
                     "TIP selection requires a residue name.",
                     component=str(source_resname),
                 )
-            names = TIP_BY_RESTYPE[source_resname]
-            if not exists(names):
+            tip_names = TIP_BY_RESTYPE[source_resname]
+            if tip_names is None:
                 raise ComponentValidationError(
                     "Residue does not define TIP atoms; use ALL, BKBN, or explicit names.",
                     component=str(source_resname),
                 )
+            names = tip_names
         elif query_names == "":
             names = []
         else:

--- a/src/foundry/utils/logging.py
+++ b/src/foundry/utils/logging.py
@@ -143,7 +143,7 @@ def print_config_tree(
 
     # Generate config tree in natural order
     for field in cfg:
-        branch = tree.add(field, style=style, guide_style=style)
+        branch = tree.add(str(field), style=style, guide_style=style)
 
         config_group = cfg[field]
         if isinstance(config_group, DictConfig):
@@ -188,7 +188,9 @@ def log_hyperparameters_with_all_loggers(
     """
     # If given a DictConfig, convert it to a dictionary
     if isinstance(cfg, DictConfig):
-        cfg = OmegaConf.to_container(cfg, resolve=True)
+        hparams = OmegaConf.to_container(cfg, resolve=True)
+    else:
+        hparams = cfg
 
     for logger in trainer.fabric.loggers:
         # ...log hyperparameters to each Fabric logger
@@ -197,7 +199,7 @@ def log_hyperparameters_with_all_loggers(
             logger, "log_hyperparams"
         ), f"Logger {logger} does not have a `log_hyperparams` method. Ensure that the logger is a subclass of Fabric's ABC `Logger`."
         try:
-            logger.log_hyperparams(cfg)
+            logger.log_hyperparams(hparams)
         except NotImplementedError:
             pass
 

--- a/src/foundry/utils/weights.py
+++ b/src/foundry/utils/weights.py
@@ -6,7 +6,7 @@ from enum import StrEnum, auto
 from os import PathLike
 
 import torch
-from beartype.typing import Pattern
+from beartype.typing import Any, Pattern
 from torch import nn
 
 from foundry.utils.ddp import RankedLogger
@@ -52,7 +52,7 @@ class _PatternPolicyMixin:
         - "model.encoder.*.bias" matches any bias parameter in encoder submodules
     """
 
-    _compiled_patterns: dict[Pattern, any]
+    _compiled_patterns: dict[Pattern, Any]
 
     @staticmethod
     def _glob_to_regex(pattern: str) -> str:
@@ -65,7 +65,7 @@ class _PatternPolicyMixin:
             .replace("]", "]")
         )
 
-    def _compile_patterns(self, policy_dict: dict[str, any]) -> dict[Pattern, any]:
+    def _compile_patterns(self, policy_dict: dict[str, Any]) -> dict[Pattern, Any]:
         compiled = {}
         for pattern, value in list(policy_dict.items()):
             if any(c in pattern for c in ["*", "?", "[", "]"]):
@@ -74,8 +74,8 @@ class _PatternPolicyMixin:
         return compiled
 
     def _get_policy_by_pattern(
-        self, param_name: str, policy_dict: dict[str, any], default: any
-    ) -> any:
+        self, param_name: str, policy_dict: dict[str, Any], default: Any
+    ) -> Any:
         # Exact match first
         if policy_dict and param_name in policy_dict:
             return policy_dict[param_name]
@@ -250,8 +250,11 @@ def load_weights_with_policies(
             ranked_logger.warning(
                 f"Failed to apply policy: '{policy}' to '{name}': {str(e)}. Falling back to policy: '{config.fallback_policy}'."
             )
+            # __post_init__ normalises fallback_policy from str to the enum.
+            fallback_policy = config.fallback_policy
+            assert isinstance(fallback_policy, WeightLoadingPolicy)
             result = _apply_policy(
-                name, current_param, checkpoint_param, config.fallback_policy
+                name, current_param, checkpoint_param, fallback_policy
             )
             updated_state[name] = result
 

--- a/src/foundry/utils/xpu/xpu_accelerator.py
+++ b/src/foundry/utils/xpu/xpu_accelerator.py
@@ -13,8 +13,8 @@ class XPUAccelerator(Accelerator):
     PyTorch's native XPU support (torch.xpu).
     """
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def name() -> str:
         """Return the name of this accelerator."""
         return "xpu"
 

--- a/src/foundry_cli/download_checkpoints.py
+++ b/src/foundry_cli/download_checkpoints.py
@@ -92,8 +92,8 @@ def download_file(url: str, dest: Path, verify_hash: Optional[str] = None) -> No
                         hasher.update(chunk)
                     progress.update(task, advance=len(chunk))
 
-    # Verify hash if provided
-    if verify_hash:
+    # Verify hash if provided (hasher is non-None exactly when verify_hash is set)
+    if hasher is not None:
         computed_hash = hasher.hexdigest()
         if computed_hash != verify_hash:
             dest.unlink()  # Remove corrupted file
@@ -246,7 +246,7 @@ def clean(
         raise typer.Exit(0)
 
     console.print("[bold]Files to delete:[/bold]")
-    total_size = 0
+    total_size = 0.0
     for ckpt in sorted(checkpoint_files, key=str):
         size = ckpt.stat().st_size / (1024**3)  # GB
         total_size += size


### PR DESCRIPTION
Type-checking: resolve the type errors in 7 modules and remove them from the `[[tool.mypy.overrides]]` `ignore_errors` list (13 → 6 remaining), so mypy now type-checks them.

Most fixes are local narrowing / annotation work. Two are deliberate type-honesty changes, each touching only an unused or impossible path:

- `SchedulerConfig.scheduler` is now a required field (was `= None`, but documented required and dereferenced unconditionally in `state_dict`/`load_state_dict`; every construction site passes `scheduler=...`). A bare `SchedulerConfig()` now raises instead of building a broken-on-first-use object.
- `XPUAccelerator.name` `@property` → `@staticmethod`, to match lightning's `Accelerator` ABC (`@staticmethod @abstractmethod def name() -> str`). No foundry code reads `.name`; lightning calls it per its own contract.

Per-module details are in the commit message.
