### PR TITLE
chore: moves dev dependencies s.t. they install with uv sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Here is an overview of how this system is structured:
 ### Installing Foundry in Editable Mode
 Install both foundry and models in editable mode for development:
 ```bash
-uv pip install -e '.[all,dev]'
+uv sync --all-extras --group dev
 ```
 This approach allows you to:
 - Modify foundry shared utilities and see changes immediately
@@ -41,10 +41,9 @@ This approach allows you to:
     ```
 
 ### As You Commit
-Foundry comes with a `.pre-commit-config.yaml` that runs `make format` (via `ruff format`) before each commit, enable it once per clone: 
+Foundry comes with a `.pre-commit-config.yaml` that runs `make format` (via `ruff format`) before each commit, enable it once per clone:
 ```bash
-pip install pre-commit # if not already installed
-pre-commit install
+uv run pre-commit install  # pre-commit is installed via the dev dependency group
 ```
 Once it is successfully installed, it will automatically format the repo whenever you run `git commit`, but you can apply it manually via `pre-commit run --all-files`.
 
@@ -59,9 +58,9 @@ Even with this, there are a few things to keep in mind to make sure your commits
 
 
 ## Adding a Model
-To be able to add new models as independent packages, make sure to install foundry and its models in 'editable' mode: 
+To be able to add new models as independent packages, make sure to install foundry and its models in 'editable' mode:
 ```bash
-uv pip install -e '.[all,dev]'
+uv sync --all-extras --group dev
 ```
 Once you have done this you can follow these steps to incorporate your model into the repository: 
 1. Create a `models/<model_name>` directory with its own `pyproject.toml`

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ clean:
 
 ## Format src directory using black
 format:
-	ruff format src models tests
-	ruff check --fix src models tests
+	uv run ruff format src models tests
+	uv run ruff check --fix src models tests
 
 #################################################################################
 # Self Documenting Commands                                                     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,26 +68,6 @@ all = [
     "rc-foundry[rfd3]",
     "rc-foundry[rf3]",
 ]
-dev = [
-    # Linters & formatters
-    "assertpy",
-    "ruff==0.8.3",
-    "ipdb",
-    # Type checking
-    "mypy>=1.13,<2",
-    # Debugger/interactive
-    "debugpy>=1.8.5,<2",
-    "ipykernel>=6.29.4,<7",
-    # Testing tools
-    "pytest>=8.2.0,<9", # testing framework
-    "pytest-testmon>=2.1.1,<3", # run only tests related to changed code
-    "pytest-xdist>=3.6.1,<4", # run tests in parallel
-    "pytest-dotenv>=0.5.2,<1", # load environment variables from .env file
-    "pytest-cov>=4.1.0,<5", # generate coverage report
-    "pytest-benchmark>=5.0.0,<6", # benchmark tests for speed
-    "atomworks[ml,dev,openbabel]>=2.1.1",
-    "pre-commit"
-]
 [project.scripts]
 rf3 = "rf3.cli:app"
 rfd3 = "rfd3.cli:app"
@@ -263,6 +243,25 @@ skip_covered = false
 
 [dependency-groups]
 dev = [
+    # Build tools
     "build>=1.3.0",
     "hatchling>=1.28.0",
+    # Linters & formatters
+    "assertpy",
+    "ruff==0.8.3",
+    "ipdb",
+    # Type checking
+    "mypy>=1.13,<2",
+    # Debugger/interactive
+    "debugpy>=1.8.5,<2",
+    "ipykernel>=6.29.4,<7",
+    # Testing tools
+    "pytest>=8.2.0,<9", # testing framework
+    "pytest-testmon>=2.1.1,<3", # run only tests related to changed code
+    "pytest-xdist>=3.6.1,<4", # run tests in parallel
+    "pytest-dotenv>=0.5.2,<1", # load environment variables from .env file
+    "pytest-cov>=4.1.0,<5", # generate coverage report
+    "pytest-benchmark>=5.0.0,<6", # benchmark tests for speed
+    "atomworks[ml,dev,openbabel]>=2.1.1",
+    "pre-commit"
 ]


### PR DESCRIPTION
This PR moves the `dev` dependencies into `dependency-groups`. That way, they're automatically included when one's developing the package and runs `uv sync`.

After this change, one doesn't have to e.g. install `ruff` or `pre-commit` before running the hooks. The make would now use `uv run ruff` instead of assuming that the `env` is active.