### PR TITLE
build: exclude tests, doc assets, and binary media from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,16 @@ packages = [
 "models/rfd3/configs" = "rfd3/configs"
 "models/rf3/configs" = "rf3/configs"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "models/*/tests/",
+  "models/*/docs/.assets/",
+  "docs/source/models/*/.assets/",
+  "**/*.pse",
+  "**/*.mp4",
+  "**/*.gif",
+]
+
 # Formatting & linting settings -------------------------------------------------------
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
The sdist for v0.2.0 ballooned to 145 MB (vs 23 MB at v0.1.10) due to new rfd3na regression fixtures and tutorial assets, exceeding PyPI's per-file limit. Excluding test data and large doc media brings the sdist to ~17 MB. The wheel is unaffected (it only packages src/ and configs/, none of which match these excludes).