### PR TITLE
fix motif drift for symmetric fused-motif designs

### DIFF
--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 import torch
 from jaxtyping import Float
+from rfd3.inference.symmetry.atom_array import FIXED_ENTITY_ID
 from rfd3.inference.symmetry.symmetry_utils import apply_symmetry_to_xyz_atomwise
 from rfd3.model.cfg_utils import strip_X
 
@@ -375,9 +376,16 @@ class SampleDiffusionWithSymmetry(SampleDiffusionWithMotif):
         # update symmetric frames to correct for change in global frame
         symmetry_feats = {k: v for k, v in f.items() if "sym" in k}
 
+        # a contiguous motif anchors the frame, so skip the COM recenter (avoids drift)
+        fixed = f.get("is_motif_atom_with_fixed_coord")
+        asu, ent = symmetry_feats["is_sym_asu"], symmetry_feats["sym_entity_id"]
+        held_motif = not self.allow_realignment and fixed is not None and bool(
+            (fixed & asu & (ent != FIXED_ENTITY_ID)).any()
+        )
+
         # apply symmetry frame shift to X_L
         X_L = apply_symmetry_to_xyz_atomwise(
-            X_L, symmetry_feats, partial_diffusion=("partial_t" in f)
+            X_L, symmetry_feats, partial_diffusion=("partial_t" in f) or held_motif
         )
 
         return X_L

--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -379,8 +379,10 @@ class SampleDiffusionWithSymmetry(SampleDiffusionWithMotif):
         # a contiguous motif anchors the frame, so skip the COM recenter (avoids drift)
         fixed = f.get("is_motif_atom_with_fixed_coord")
         asu, ent = symmetry_feats["is_sym_asu"], symmetry_feats["sym_entity_id"]
-        held_motif = not self.allow_realignment and fixed is not None and bool(
-            (fixed & asu & (ent != FIXED_ENTITY_ID)).any()
+        held_motif = (
+            not self.allow_realignment 
+            and fixed is not None 
+            and bool((fixed & asu & (ent != FIXED_ENTITY_ID)).any())
         )
 
         # apply symmetry frame shift to X_L

--- a/models/rfd3/src/rfd3/model/inference_sampler.py
+++ b/models/rfd3/src/rfd3/model/inference_sampler.py
@@ -380,8 +380,8 @@ class SampleDiffusionWithSymmetry(SampleDiffusionWithMotif):
         fixed = f.get("is_motif_atom_with_fixed_coord")
         asu, ent = symmetry_feats["is_sym_asu"], symmetry_feats["sym_entity_id"]
         held_motif = (
-            not self.allow_realignment 
-            and fixed is not None 
+            not self.allow_realignment
+            and fixed is not None
             and bool((fixed & asu & (ent != FIXED_ENTITY_ID)).any())
         )
 


### PR DESCRIPTION
## Issue
When scaffolding a fused/contiguous motif under symmetry (`inference_sampler.kind=symmetry`), the motif drifts over the trajectory so the output no longer matches the input motif.

Symmetric inference applies a per-step COM recenter, then rebuilds the symmetric copies from the ASU. A fused motif is part of the generated chain, so it isn't marked `FIXED_ENTITY_ID` and nothing corrects for the shift. The recenter, propagated through the symmetry transforms, moves the motif off its input pose and the error accumulates over the trajectory.

## Fix
In `SampleDiffusionWithSymmetry.apply_symmetry_to_X_L`, we skip the COM recenter when a contiguous motif is present, so it stays put and the symmetric copies rebuild from it correctly.

### Scope
Scoped to `is_motif_atom_with_fixed_coord & is_sym_asu & ~FIXED_ENTITY_ID` and guarded by `not self.allow_realignment`, so it's a no-op for de novo symmetric, unindexed motifs, and the non-symmetric sampler.