### PR TITLE
Bring models/mpnn into the mypy gate; finish clearing rfd3 type-checking

### DIFF
--- a/models/rfd3/src/rfd3/engine.py
+++ b/models/rfd3/src/rfd3/engine.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass, field
 from os import PathLike
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 import torch
 import yaml
@@ -202,13 +202,15 @@ class RFD3InferenceEngine(BaseInferenceEngine):
             # HACK: Set attribute to the diffusion module
             os.environ["RFD3_LOW_MEMORY_MODE"] = "1"
 
-    def run(
+    # The base `run` is positional (`inputs, *_`); this engine deliberately exposes a
+    # richer keyword-only API, so the override is intentionally LSP-incompatible.
+    def run(  # type: ignore[override]
         self,
         *,
         inputs: str | PathLike | AtomArray | DesignInputSpecification,
         n_batches: int | None = None,
         out_dir: str | PathLike | None = None,
-    ):
+    ) -> dict[str, list[RFD3Output]] | None:
         self._set_out_dir(out_dir)
         inputs = self._canonicalize_inputs(inputs)
         design_specifications = self._multiply_specifications(
@@ -382,7 +384,7 @@ class RFD3InferenceEngine(BaseInferenceEngine):
         self, inputs: Dict[str, dict | DesignInputSpecification], n_batches=None
     ) -> Dict[str, dict | DesignInputSpecification]:
         # Find existing example IDS in output directory
-        if exists(self.out_dir):
+        if self.out_dir is not None:
             existing_example_ids_ = set(
                 extract_example_id_from_path(path, CIF_LIKE_EXTENSIONS)
                 for path in find_files_with_extension(self.out_dir, CIF_LIKE_EXTENSIONS)
@@ -437,10 +439,11 @@ def normalize_inputs(inputs: str | list | None) -> list[str | None]:
         - Returns list of paths or [None] if no inputs are provided
     """
     if inputs is None or (isinstance(inputs, list) and len(inputs) == 0):
-        inputs = [None]
-    elif isinstance(inputs, str):
-        inputs = inputs.split(",")
-    elif not isinstance(inputs, list):
+        return [None]
+    if isinstance(inputs, str):
+        # str.split yields list[str]; widen to the union return type (list is invariant).
+        return cast(list[str | None], inputs.split(","))
+    if not isinstance(inputs, list):
         raise ValueError(
             f"Invalid input type: {type(inputs)}. Expected str, list, or None.\nInput: {inputs}"
         )
@@ -482,20 +485,10 @@ def process_input(
     else:
         use_json_basename_prefix = False
 
-    # ... Convert all inputs to list of inputs (e.g. if comma-separated)
-    if exists(inputs) and "," in inputs:
-        inputs = inputs.split(",")
-    elif not exists(inputs):
-        # If inputs is None or empty, we will create a dummy input
-        inputs = []
-    inputs = inputs if isinstance(inputs, list) else [inputs]
-    if len(inputs) == 0:
-        inputs = [None]
-
     # ... Determine prefix of sample to create
     all_specs = {}
     for input in inputs:
-        if exists(input) and (input.endswith(".json") or input.endswith(".yaml")):
+        if input is not None and (input.endswith(".json") or input.endswith(".yaml")):
             # ... Load JSON or YAML file
             with open(input, "r") as f:
                 data = json.load(f) if input.endswith(".json") else yaml.safe_load(f)
@@ -530,7 +523,7 @@ def process_input(
                 args["extra"] = args.get("extra", {}) | {"example": example}
                 all_specs[prefix] = dict(merge_args(args))
 
-        elif exists(input):
+        elif input is not None:
             prefix = os.path.basename(os.path.splitext(input)[0])
             if global_prefix is not None:
                 prefix = f"{global_prefix}{prefix}"

--- a/models/rfd3/src/rfd3/inference/legacy_input_parsing.py
+++ b/models/rfd3/src/rfd3/inference/legacy_input_parsing.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import logging
 from os import PathLike
-from typing import Dict
+from typing import Dict, cast
 
 import biotite.structure as struc
 import numpy as np
@@ -36,6 +36,7 @@ from rfd3.utils.inference import (
     set_com,
     set_common_annotations,
     set_indices,
+    spoof_helical_bundle_ss_conditioning_fn,
 )
 
 from foundry.common import exists
@@ -636,22 +637,22 @@ def accumulate_components(
 def create_atom_array_from_design_specification_legacy(
     *,
     # Specification args:
-    input: PathLike = None,
+    input: PathLike | None = None,
     length: str = "100-300",
-    contig: str = None,
-    fixed_atoms: dict = None,
-    unindex: str = None,
-    unfix_sequence: str = None,
+    contig: str | None = None,
+    fixed_atoms: dict | None = None,
+    unindex: str | None = None,
+    unfix_sequence: str | None = None,
     redesign_motif_sidechains: bool = False,
     unfix_all=False,
-    unfix_specific: str = None,
+    unfix_specific: str | list | None = None,
     flexible_backbone: bool = False,
     # Args for biomolecular design (Enzymes, DNA/PNA):
-    ligand: str = None,
-    ori_token: list[float] = None,
+    ligand: str | None = None,
+    ori_token: list[float] | None = None,
     infer_ori_strategy: str | None = None,
-    atomwise_rasa: dict = None,
-    atomwise_hbond: dict = None,
+    atomwise_rasa: dict | None = None,
+    atomwise_hbond: dict | None = None,
     # Additional args:
     out_path=None,
     cif_parser_args=None,
@@ -662,7 +663,7 @@ def create_atom_array_from_design_specification_legacy(
     is_sheet: dict | None = None,
     is_loop: dict | None = None,
     spoof_helical_bundle_ss_conditioning: bool = False,
-    symmetry: dict = None,
+    symmetry: dict | None = None,
     # Low-temperature global conditioning args
     plddt_enhanced: bool = True,
     is_non_loopy: bool | None = None,
@@ -694,12 +695,12 @@ def create_atom_array_from_design_specification_legacy(
     ###########################################################################################################################
 
     # 1) Load input data if provided
-    if exists(input):
+    if input is not None:
         atom_array_input = inference_load_(input, cif_parser_args=cif_parser_args)[
             "atom_array"
         ]
         # If we are doing symmetric design, we need to center the full input atom array at the origin (for getting symmetry frames)
-        if exists(symmetry) and symmetry.get("id"):
+        if symmetry is not None and symmetry.get("id"):
             atom_array_input = center_symmetric_src_atom_array(atom_array_input)
     elif exists(contig) or exists(length):
         atom_array_input = None
@@ -710,12 +711,10 @@ def create_atom_array_from_design_specification_legacy(
     if exists(length) and not exists(contig):
         # Handle cases where contigs aren't specified
         if not exists(unindex) and not exists(flexible_backbone):
-            if exists(fixed_atoms):
+            if fixed_atoms is not None:
                 # ensure that fixed atoms are in the input, else raise error
-                _ = [
+                for key in fixed_atoms.keys():
                     fetch_mask_from_component(key, atom_array=atom_array_input)
-                    for key in fixed_atoms.keys()
-                ]
             ranked_logger.warning(
                 "No input contig specified and no motif, running unconditional generation"
             )
@@ -723,14 +722,14 @@ def create_atom_array_from_design_specification_legacy(
         contig = length
     else:
         indexed_components_provided = True
-    if not exists(fixed_atoms):
+    if fixed_atoms is None:
         fixed_atoms = {}
 
     optional_conditions = []
     if exists(atomwise_rasa):
         set_atom_level_argument(atom_array_input, atomwise_rasa, "rasa_bin")
         optional_conditions.append("rasa_bin")
-    if exists(atomwise_hbond):
+    if atomwise_hbond is not None:
         for key, value in atomwise_hbond.items():
             set_atom_level_argument(atom_array_input, value, key)
             optional_conditions.append(key)
@@ -741,8 +740,10 @@ def create_atom_array_from_design_specification_legacy(
         optional_conditions.append("is_atom_level_hotspot")
 
     # 2) Parse contigs into components
+    # contig is always set by here: it is either provided or defaulted to `length`
+    # above (length is non-optional), so the cast documents that invariant for mypy.
     indexed_components = get_design_pattern_with_constraints(
-        contig, length
+        cast(str, contig), length
     )  # e.g. [2, A20, A21, 2, A25, 3, A30, /0, 3]
 
     # Parse redesign_motif_sidechains if necessary
@@ -754,7 +755,7 @@ def create_atom_array_from_design_specification_legacy(
 
     # ... Add unindexed components
     unindexed_components, unindexed_breaks = (
-        get_motif_components_and_breaks(unindex) if exists(unindex) else ([], [])
+        get_motif_components_and_breaks(unindex) if unindex is not None else ([], [])
     )
     breaks = [None] * len(indexed_components) + unindexed_breaks
     assert_non_intersecting_contigs(indexed_components, unindexed_components)
@@ -765,16 +766,16 @@ def create_atom_array_from_design_specification_legacy(
     )
 
     # Determine which residues to unfix
-    unfix_residues = []
+    unfix_residues: list[str] = []
     if isinstance(unfix_specific, list):
         unfix_residues = [str(u) for u in unfix_specific]
     elif isinstance(unfix_specific, str):
         if unfix_specific.upper() == "ALL":
             unfix_all = True
         elif unfix_specific:
-            unfix_residues, _ = get_motif_components_and_breaks(
+            unfix_residues = get_motif_components_and_breaks(
                 unfix_specific, index_all=True
-            )
+            )[0]
 
     # 3) Create atom array from components
     if exists(partial_t):
@@ -884,7 +885,7 @@ def create_atom_array_from_design_specification_legacy(
         atom_array = atom_array + ligand_array
 
     # ... Apply symmetry if it exists ahead of any other processing
-    if exists(symmetry) and symmetry.get("id"):
+    if symmetry is not None and symmetry.get("id"):
         atom_array = make_symmetric_atom_array(
             atom_array, symmetry, sm=ligand, src_atom_array=atom_array_input
         )
@@ -892,7 +893,7 @@ def create_atom_array_from_design_specification_legacy(
     # ... Input frame and ORI token handling
     if exists(partial_t):
         # For symmetric structures, avoid COM centering that would collapse chains
-        if exists(symmetry) and symmetry.get("id"):
+        if symmetry is not None and symmetry.get("id"):
             ranked_logger.info(
                 "Partial diffusion with symmetry: skipping COM centering to preserve chain spacing"
             )

--- a/models/rfd3/src/rfd3/trainer/fabric_trainer.py
+++ b/models/rfd3/src/rfd3/trainer/fabric_trainer.py
@@ -23,7 +23,6 @@ from lightning.fabric.accelerators import Accelerator
 from lightning.fabric.loggers import Logger
 from lightning.fabric.strategies import DDPStrategy, Strategy
 from lightning.fabric.wrappers import (
-    _FabricDataLoader,
     _FabricModule,
     _FabricOptimizer,
 )
@@ -38,6 +37,13 @@ logger = RankedLogger(__name__, rank_zero_only=False)
 
 
 class FabricTrainer(ABC):
+    # Heterogeneous, dynamically-keyed training state: model / optimizer / scheduler_cfg
+    # plus step & epoch counters and the train config, and extended with arbitrary
+    # checkpoint keys on load. A loose bag by design, not a fixed-shape struct.
+    state: dict[str, Any]
+    # Set by subclass training_step() implementations before on_train_batch_end fires.
+    _current_train_return: Any
+
     def __init__(
         self,
         *,
@@ -110,7 +116,8 @@ class FabricTrainer(ABC):
             strategy=strategy,
             devices=devices_per_node,
             num_nodes=num_nodes,
-            precision=precision,
+            # Our public str | int API is wider than Fabric's precision Literal union.
+            precision=precision,  # type: ignore[arg-type]
             callbacks=callbacks,
             loggers=loggers,
         )
@@ -152,7 +159,7 @@ class FabricTrainer(ABC):
                 (for training or for inference). Default is an empty dictionary.
         """
         # Default values for the state
-        default_state = {
+        default_state: dict[str, Any] = {
             "model": None,
             "optimizer": None,
             "scheduler_cfg": None,
@@ -286,16 +293,22 @@ class FabricTrainer(ABC):
         )
 
         # ... setup training and validation dataloaders with Fabric
-        train_loader = self.fabric.setup_dataloaders(
-            # Our sampler is already distributed, so we don't need to wrap with a DistributedSampler
-            train_loader,
-            use_distributed_sampler=False,
+        train_loader = cast(
+            torch.utils.data.DataLoader,
+            self.fabric.setup_dataloaders(
+                # Our sampler is already distributed, so we don't need to wrap with a DistributedSampler
+                train_loader,
+                use_distributed_sampler=False,
+            ),
         )
 
         if val_loaders is not None:
             for key, loader in val_loaders.items():
-                val_loaders[key] = self.fabric.setup_dataloaders(
-                    loader, use_distributed_sampler=False
+                val_loaders[key] = cast(
+                    torch.utils.data.DataLoader,
+                    self.fabric.setup_dataloaders(
+                        loader, use_distributed_sampler=False
+                    ),
                 )
 
         self.setup_model_optimizers_and_schedulers()
@@ -307,7 +320,9 @@ class FabricTrainer(ABC):
                 ranked_logger.info(
                     f"Loading latest checkpoint within the directory {ckpt_path}..."
                 )
-                self.load_checkpoint(self.get_latest_checkpoint(ckpt_path))
+                # We are resuming from a directory that should contain checkpoints;
+                # get_latest_checkpoint returns None only if it is empty (latent edge).
+                self.load_checkpoint(cast(Path, self.get_latest_checkpoint(ckpt_path)))
             else:
                 # If given a specific checkpoint file, load that checkpoint
                 self.load_checkpoint(ckpt_path)
@@ -397,7 +412,7 @@ class FabricTrainer(ABC):
     def train_loop(
         self,
         *,
-        train_loader: _FabricDataLoader,
+        train_loader: torch.utils.data.DataLoader,
         limit_batches: int | float = float("inf"),
     ):
         """Train model for a single epoch.
@@ -503,7 +518,7 @@ class FabricTrainer(ABC):
     def validation_loop(
         self,
         *,
-        val_loaders: dict[str, _FabricDataLoader],
+        val_loaders: dict[str, torch.utils.data.DataLoader],
         limit_batches: int | float = float("inf"),
     ):
         """Run validation loop for a single validation epoch.
@@ -832,7 +847,7 @@ class FabricTrainer(ABC):
             )
             self.load_legacy_checkpoint(ckpt)
 
-    def load_legacy_checkpoint(self, ckpt: dict) -> dict:
+    def load_legacy_checkpoint(self, ckpt: dict) -> None:
         # TODO: Remove when no longer needed
         """Backwards-compatibility function to checkpoints with legacy state formats"""
         new_model_state = {}
@@ -895,7 +910,7 @@ class FabricTrainer(ABC):
         )
 
     @staticmethod
-    def get_latest_checkpoint(ckpt_load_dir: Path) -> Path:
+    def get_latest_checkpoint(ckpt_load_dir: Path) -> Path | None:
         """Returns the latest checkpoint file from the given directory.
 
         Assumes that checkpoints are stored with filenames such that a standard string-based

--- a/models/rfd3/src/rfd3/utils/io.py
+++ b/models/rfd3/src/rfd3/utils/io.py
@@ -199,12 +199,14 @@ def build_stack_from_atom_array_and_batched_coords(
     return atom_array_stack
 
 
-def find_files_with_extension(path: PathLike, supported_file_types: list) -> list[Path]:
+def find_files_with_extension(
+    path: PathLike, supported_file_types: set | list
+) -> list[Path]:
     """Find files with the given extensions at the top level of the path (non-recursive).
 
     Args:
         path (PathLike): Path to the directory containing the files.
-        supported_file_types (list): List of supported file extensions.
+        supported_file_types (set | list): Supported file extensions.
 
     Returns:
         list[Path]: List of files with the given extensions.

--- a/models/rfd3/src/rfd3/utils/vizualize.py
+++ b/models/rfd3/src/rfd3/utils/vizualize.py
@@ -110,7 +110,9 @@ def get_atom_array_style_cmd(
     if hasattr(atom_array, "_annot_2d"):
         distance_commands = []
         if C_DIS.full_name in atom_array._annot_2d:
-            constraint_data = C_DIS.annotation(atom_array).as_array()
+            # atomworks types `annotation()` as `-> np.ndarray`, but the runtime
+            # 2-body annotation object exposes `.as_array()` to materialise the ndarray.
+            constraint_data = C_DIS.annotation(atom_array).as_array()  # type: ignore[attr-defined]
             if len(constraint_data) > 0:
                 _atom_idxs = np.unique(constraint_data[:, :2].flatten()).astype(int)
                 _atom_ids = atom_ids[_atom_idxs]
@@ -257,15 +259,11 @@ def _viz_from_file(
             atom_array = pickle.load(f)
     elif file_path.endswith((".cif", ".cif.gz", ".bcif", ".bcif.gz")):
         from atomworks.io.utils.io_utils import get_structure, read_any
-        from rfd3.utils.inference import (
-            _add_design_annotations_from_cif_block_metadata,
-        )
 
-        cif_file = read_any(file_path)
+        # NOTE: design-annotation restore from CIF block metadata was removed in the
+        # open-sourcing refactor (the helper no longer exists), so load the plain structure.
+        cif_file = read_any(pathlib.Path(file_path))
         atom_array = get_structure(cif_file, include_bonds=True, extra_fields="all")
-        atom_array = _add_design_annotations_from_cif_block_metadata(
-            atom_array, cif_file.block
-        )
     viz(atom_array, id=id, clear=clear, label=label, max_distances=max_distances)
 
 

--- a/models/rfd3/tests/test_rfd3_engine.py
+++ b/models/rfd3/tests/test_rfd3_engine.py
@@ -1,0 +1,49 @@
+"""Unit tests for ``rfd3.engine.normalize_inputs``.
+
+``normalize_inputs`` is the pure input-normaliser that ``process_input`` relies on to
+turn the engine's flexible ``inputs`` argument into a uniform list before the spec loop.
+Its contract:
+
+- ``None`` or an empty list -> ``[None]`` (the dummy-input sentinel used for motif-only
+  design),
+- a comma-separated string -> the split list of paths,
+- a single-path string -> a one-element list,
+- a list -> returned unchanged,
+- anything else -> ``ValueError``.
+
+Pinning this contract guards the simplification in ``process_input``, which trusts
+``normalize_inputs`` to have already done all of the list/comma/empty normalisation.
+
+Named ``test_rfd3_engine`` to avoid a pytest basename clash under the suite's prepend
+import mode.
+"""
+
+import pytest
+from rfd3.engine import normalize_inputs
+
+
+def test_none_becomes_dummy_input():
+    assert normalize_inputs(None) == [None]
+
+
+def test_empty_list_becomes_dummy_input():
+    assert normalize_inputs([]) == [None]
+
+
+def test_single_path_string_is_wrapped():
+    assert normalize_inputs("a.json") == ["a.json"]
+
+
+def test_comma_separated_string_is_split():
+    assert normalize_inputs("a.json,b.json,c.cif") == ["a.json", "b.json", "c.cif"]
+
+
+def test_list_is_returned_unchanged():
+    paths = ["a.json", "b.json"]
+    result = normalize_inputs(paths)
+    assert result == ["a.json", "b.json"]
+
+
+def test_invalid_type_raises_value_error():
+    with pytest.raises(ValueError):
+        normalize_inputs(5)  # type: ignore[arg-type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,20 +224,10 @@ warn_redundant_casts = true
 disallow_untyped_defs = false
 check_untyped_defs = false
 
-# rfd3 enablement ratchet. `models/rfd3` was brought into mypy's scope in 0010;
-# these modules had pre-existing type errors at that point and are exempted until
-# annotated. Fix the errors and remove the entry to enable type-checking for that
-# module (same playbook as the now-cleared src/foundry ratchet). Do NOT add modules.
-[[tool.mypy.overrides]]
-module = [
-    # Held back: `process_input`/`normalize_inputs` have confused pre-existing logic
-    # (a `.split(",")` on a value that is already a list — dead but type-incorrect). See roadmap.
-    "rfd3.engine",
-    # Held back: imports `rfd3.utils.inference._add_design_annotations_from_cif_block_metadata`,
-    # which does not exist (broken import — would ImportError on the .cif-load path). See roadmap.
-    "rfd3.utils.vizualize",
-]
-ignore_errors = true
+# NOTE: the rfd3 enablement ratchet (0010) is fully cleared — there is no rfd3 module-level
+# mypy exemption here. `models/rfd3` was brought into mypy's scope in 0010 behind an
+# `ignore_errors` ratchet; every exempted module has since been annotated and removed (same
+# playbook as the now-cleared src/foundry and rf3 ratchets).
 
 # NOTE: the rf3 enablement ratchet (0014) is fully cleared — there is no rf3 module-level
 # mypy exemption here, and every rf3 module type-checks with no in-file suppressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,6 @@ module = [
     # (a `.split(",")` on a value that is already a list — dead but type-incorrect). See roadmap.
     "rfd3.engine",
     "rfd3.inference.legacy_input_parsing",
-    "rfd3.trainer.fabric_trainer",
     # Held back: imports `rfd3.utils.inference._add_design_annotations_from_cif_block_metadata`,
     # which does not exist (broken import — would ImportError on the .cif-load path). See roadmap.
     "rfd3.utils.vizualize",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,6 @@ module = [
     # Held back: `process_input`/`normalize_inputs` have confused pre-existing logic
     # (a `.split(",")` on a value that is already a list — dead but type-incorrect). See roadmap.
     "rfd3.engine",
-    "rfd3.inference.legacy_input_parsing",
     # Held back: imports `rfd3.utils.inference._add_design_annotations_from_cif_block_metadata`,
     # which does not exist (broken import — would ImportError on the .cif-load path). See roadmap.
     "rfd3.utils.vizualize",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,13 @@ typeCheckingMode = "off"
 # Per-module strictness is ratcheted up via [tool.mypy.overrides] as annotations land.
 [tool.mypy]
 python_version = "3.12"
-files = ["src/foundry", "src/foundry_cli", "models/rfd3/src/rfd3", "models/rf3/src/rf3"]
+files = [
+    "src/foundry",
+    "src/foundry_cli",
+    "models/rfd3/src/rfd3",
+    "models/rf3/src/rf3",
+    "models/mpnn/src/mpnn",
+]
 ignore_missing_imports = true
 warn_unused_ignores = true
 warn_redundant_casts = true
@@ -231,6 +237,25 @@ check_untyped_defs = false
 
 # NOTE: the rf3 enablement ratchet (0014) is fully cleared — there is no rf3 module-level
 # mypy exemption here, and every rf3 module type-checks with no in-file suppressions.
+
+# mpnn enablement ratchet (0063): `models/mpnn/src/mpnn` was brought into mypy's scope behind
+# this `ignore_errors` ratchet (same playbook as the now-cleared src/foundry, rf3, and rfd3
+# ratchets). The listed modules still have errors; they are cleared one slice per task and
+# removed from this list, after which the block is deleted entirely.
+[[tool.mypy.overrides]]
+module = [
+    "mpnn.collate.feature_collator",
+    "mpnn.inference_engines.mpnn",
+    "mpnn.pipelines.mpnn",
+    "mpnn.samplers.samplers",
+    "mpnn.train",
+    "mpnn.trainers.mpnn",
+    "mpnn.transforms.feature_aggregation.token_encodings",
+    "mpnn.transforms.feature_aggregation.user_settings",
+    "mpnn.utils.inference",
+    "mpnn.utils.weights",
+]
+ignore_errors = true
 
 # Per-module strictness (direction (b)). The global baseline above leaves
 # disallow_untyped_defs / check_untyped_defs off; the whole shared layer


### PR DESCRIPTION
Extends the type-check gate across two model packages.

**rfd3 — finishes type-checking the package.** Clears the last rfd3 modules that were still exempted from `mypy`: `trainer/fabric_trainer` (the FabricTrainer state-bag, mirroring the shared-layer FabricTrainer), `inference/legacy_input_parsing`, and `engine` + `utils/vizualize`. These were the final exemptions, so all of `models/rfd3` now type-checks with no module-level suppressions. The changes are type-annotation-only except for a few genuine latent-bug fixes surfaced by honest typing (a missing import in `legacy_input_parsing`, a dead/incorrect import + a dead `.split`-on-a-list block in the engine, a broken `vizualize` import removed). Adds `test_rfd3_engine.py` (6 tests) pinning the `normalize_inputs` contract.

**mpnn — adds the package to the gate.** Brings `models/mpnn/src/mpnn` into mypy's scope behind a fresh `ignore_errors` ratchet listing the 10 modules that currently have type errors, so the gate stays green while they are cleared one module at a time in follow-up PRs (the same approach already used for the shared layer, rf3, and rfd3). The other 14 mpnn modules type-check clean and are gated now.

Verification: `ruff` format/check clean; `mypy` Success (176 files); `pytest` 492 passed / 10 skipped.