### PR TITLE
is_motif_atom_with_fixed_coord fix

### DIFF
--- a/models/rfd3/src/rfd3/transforms/virtual_atoms.py
+++ b/models/rfd3/src/rfd3/transforms/virtual_atoms.py
@@ -221,6 +221,12 @@ class PadTokensWithVirtualAtoms(Transform):
                     # ... Even if the input pad_atoms are all motif, we don't ever want padded atoms to be motif
                     pad_array.is_motif_atom = np.zeros(n_pad, dtype=bool)
 
+                    #... Pad_atoms should never inherit fixed state
+                    if data["is_inference"]:
+                        pad_array.is_motif_atom_with_fixed_coord = np.zeros(
+                            n_pad, dtype=token.is_motif_atom_with_fixed_coord.dtype
+                        )
+                        
                     # Handle multidimensional annotations
                     def _fix_multidimensional_annotations_in_pad_array(
                         atomarray, padarray

--- a/models/rfd3na/src/rfd3na/transforms/virtual_atoms.py
+++ b/models/rfd3na/src/rfd3na/transforms/virtual_atoms.py
@@ -260,6 +260,12 @@ class PadTokensWithVirtualAtoms(Transform):
                     # ... Even if the input pad_atoms are all motif, we don't ever want padded atoms to be motif
                     pad_array.is_motif_atom = np.zeros(n_pad, dtype=bool)
 
+                    #... Pad_atoms should never inherit fixed state
+                    if data["is_inference"]:
+                        pad_array.is_motif_atom_with_fixed_coord = np.zeros(
+                            n_pad, dtype=token.is_motif_atom_with_fixed_coord.dtype
+                        )
+                        
                     # Handle multidimensional annotations
                     def _fix_multidimensional_annotations_in_pad_array(
                         atomarray, padarray


### PR DESCRIPTION
As per my bug report, I added a line to not carry the is_motif_atom_with_fixed_coord flag for pad_atoms after .copy()
Improves motif scaffolding backbone quality for certain tasks.